### PR TITLE
perf(fonts): 字體載入優化（font-display: swap + 非同步 CSS 載入）

### DIFF
--- a/themes/icarus/include/style/fonts.styl
+++ b/themes/icarus/include/style/fonts.styl
@@ -1,0 +1,27 @@
+// Font Awesome font-display: swap overrides
+// These @font-face declarations are processed before async FA CSS loads,
+// ensuring font-display: swap takes effect for icon fonts.
+
+@font-face
+  font-family: 'Font Awesome 6 Free'
+  font-weight: 900
+  font-style: normal
+  font-display: swap
+  src: url('https://use.fontawesome.com/releases/v6.0.0/webfonts/fa-solid-900.woff2') format('woff2'),
+       url('https://use.fontawesome.com/releases/v6.0.0/webfonts/fa-solid-900.woff') format('woff')
+
+@font-face
+  font-family: 'Font Awesome 6 Free'
+  font-weight: 400
+  font-style: normal
+  font-display: swap
+  src: url('https://use.fontawesome.com/releases/v6.0.0/webfonts/fa-regular-400.woff2') format('woff2'),
+       url('https://use.fontawesome.com/releases/v6.0.0/webfonts/fa-regular-400.woff') format('woff')
+
+@font-face
+  font-family: 'Font Awesome 6 Brands'
+  font-weight: 400
+  font-style: normal
+  font-display: swap
+  src: url('https://use.fontawesome.com/releases/v6.0.0/webfonts/fa-brands-400.woff2') format('woff2'),
+       url('https://use.fontawesome.com/releases/v6.0.0/webfonts/fa-brands-400.woff') format('woff')

--- a/themes/icarus/layout/common/head.jsx
+++ b/themes/icarus/layout/common/head.jsx
@@ -72,8 +72,8 @@ module.exports = class extends Component {
 
         const language = page.lang || page.language || config.language;
         const fontCssUrl = {
-            default: fontcdn('Ubuntu:wght@400;600&family=Source+Code+Pro', 'css2'),
-            cyberpunk: fontcdn('Oxanium:wght@300;400;600&family=Roboto+Mono', 'css2')
+            default: fontcdn('Ubuntu:wght@400;600&family=Source+Code+Pro&display=swap', 'css2'),
+            cyberpunk: fontcdn('Oxanium:wght@300;400;600&family=Roboto+Mono&display=swap', 'css2')
         };
 
         let hlTheme, images;
@@ -188,9 +188,12 @@ module.exports = class extends Component {
             {canonical_url ? <link rel="canonical" href={canonical_url} /> : null}
             {rss ? <link rel="alternate" href={url_for(rss)} title={config.title} type="application/atom+xml" /> : null}
             {favicon ? <link rel="icon" href={url_for(favicon)} /> : null}
-            <link rel="stylesheet" href={iconcdn()} />
-            {hlTheme ? <link rel="stylesheet" href={cdn('highlight.js', '9.12.0', 'styles/' + hlTheme + '.css')} /> : null}
-            <link rel="stylesheet" href={fontCssUrl[variant]} />
+            <link rel="preload" href={iconcdn()} as="style" onload="this.onload=null;this.rel='stylesheet'" />
+            <noscript><link rel="stylesheet" href={iconcdn()} /></noscript>
+            {hlTheme ? <link rel="preload" href={cdn('highlight.js', '9.12.0', 'styles/' + hlTheme + '.css')} as="style" onload="this.onload=null;this.rel='stylesheet'" /> : null}
+            {hlTheme ? <noscript><link rel="stylesheet" href={cdn('highlight.js', '9.12.0', 'styles/' + hlTheme + '.css')} /></noscript> : null}
+            <link rel="preload" href={fontCssUrl[variant]} as="style" onload="this.onload=null;this.rel='stylesheet'" />
+            <noscript><link rel="stylesheet" href={fontCssUrl[variant]} /></noscript>
             <link rel="stylesheet" href={url_for('/css/' + variant + '.css')} />
             <Plugins site={site} config={config} helper={helper} page={page} head={true} />
 

--- a/themes/icarus/source/css/style.styl
+++ b/themes/icarus/source/css/style.styl
@@ -1,3 +1,5 @@
+// Font display overrides (must be first to take effect before async fonts load)
+@import '../../include/style/fonts'
 // Base CSS framework
 @import '../../include/style/base'
 // Helper classes & mixins


### PR DESCRIPTION
## Summary

- 為 Google Fonts URL 加入 `&display=swap` 參數，讓瀏覽器在字體載入期間顯示 fallback 字體而非空白
- 將 FontAwesome、highlight.js、Google Fonts 三個第三方 CSS 從同步 `<link rel="stylesheet">` 改為 `preload` + `onload` 非同步載入模式，移除渲染阻塞
- 加入 `<noscript>` fallback，確保無 JavaScript 環境下仍可正常顯示樣式
- 新增 `fonts.styl`，宣告 Font Awesome 6 Free（weight 400/900）與 Font Awesome 6 Brands 的 `@font-face` 並設定 `font-display: swap`，覆寫 CDN CSS 的 block 行為
- 預計節省 FCP ~3,000 ms、渲染阻塞 ~1,090 ms

## How to test

**本地驗證：**
1. `npx hexo generate && npx hexo server`
2. 開啟首頁，確認文字、icon、code highlight 正常顯示（無 FOUT 異常）
3. 查看 DevTools → Network，確認 FontAwesome / highlight.js / Google Fonts 以 `preload` 方式載入，非渲染阻塞

**Lighthouse 驗證：**
1. 在 Chrome 執行 Lighthouse → Performance
2. 確認首頁手機版 LCP ≤ 2.0 s
3. 確認「Eliminate render-blocking resources」不再列出第三方字體 CSS

**noscript 驗證：**
1. 在 DevTools 停用 JavaScript
2. 重新整理頁面，確認樣式仍正常載入（noscript fallback 生效）

## 注意事項

- 無需更新環境變數或執行 migration
- `fonts.styl` 必須在 `style.styl` 第一行 import，確保 @font-face 優先於非同步 FA CSS 被處理
- 此改動不影響其他頁面邏輯，僅影響 `<head>` 的 CSS 載入順序