### PR TITLE
feat(seo): 社群 Meta Tags 實作（Open Graph + Twitter Card）

### DIFF
--- a/_config.icarus.yml
+++ b/_config.icarus.yml
@@ -11,7 +11,7 @@ head:
         site_name:
         author:
         description:
-        twitter_card:
+        twitter_card: summary_large_image
         twitter_id:
         twitter_site:
         google_plus:

--- a/themes/icarus/layout/common/head.jsx
+++ b/themes/icarus/layout/common/head.jsx
@@ -170,6 +170,13 @@ module.exports = class extends Component {
                 facebookAdmins={open_graph.fb_admins}
                 facebookAppId={open_graph.fb_app_id} /> : null}
 
+            {typeof open_graph === 'object' && open_graph !== null ? <meta property="twitter:title" content={open_graph.title || page.title || config.title} /> : null}
+            {typeof open_graph === 'object' && open_graph !== null ? (() => {
+                const raw = open_graph.description || page.description || page.excerpt || page.content || config.description;
+                const desc = raw ? stripHTML(raw).substring(0, 200).trim().replace(/\n/g, ' ') : '';
+                return <meta property="twitter:description" content={desc} />;
+            })() : null}
+
             {is_post(page)
                 ? <script type="application/ld+json"
                     dangerouslySetInnerHTML={{ __html: JSON.stringify(buildArticleJsonLd(page, config, structuredImages)) }} />


### PR DESCRIPTION
## Summary

- 設定 `twitter_card: summary_large_image` 在 `_config.icarus.yml`，讓 Twitter 社群分享顯示大圖預覽
- 在 `themes/icarus/layout/common/head.jsx` 新增 `twitter:title` 與 `twitter:description` meta tags
- OG tags（`og:title`、`og:description`、`og:image`、`og:type`、`og:url`）已由 Icarus OpenGraph 元件完整涵蓋
- 預設 `og:image` 使用 `/img/og_image.png`（1200×630 px，符合 OG 規範）
- 文章頁若有 `cover`/`thumbnail`，自動替換為文章封面圖

## 驗收確認

- [x] 所有頁面含 `og:title`、`og:description`、`og:image`、`og:type`、`og:url`
- [x] 所有頁面含 `twitter:card`、`twitter:title`、`twitter:description`、`twitter:image`
- [x] 文章頁的 `og:image` 優先使用 cover/thumbnail，fallback 為預設封面
- [x] 圖片尺寸符合 OG 規範（1200×630 px）
- [ ] 使用 Facebook Sharing Debugger 驗證（需部署後手動確認）

## Test plan

- `npm run build` 成功無 error
- 驗證生成的 HTML 包含所有必要 meta tags
- 需部署後用 Facebook Sharing Debugger 做最終驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)