### PR TITLE
fix(perf): 修正 async Google Fonts 造成文章頁 LCP 退步（BOLA-25）

### DIFF
--- a/themes/icarus/layout/common/head.jsx
+++ b/themes/icarus/layout/common/head.jsx
@@ -195,12 +195,13 @@ module.exports = class extends Component {
             {canonical_url ? <link rel="canonical" href={canonical_url} /> : null}
             {rss ? <link rel="alternate" href={url_for(rss)} title={config.title} type="application/atom+xml" /> : null}
             {favicon ? <link rel="icon" href={url_for(favicon)} /> : null}
+            <link rel="preconnect" href="https://fonts.googleapis.com" />
+            <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+            <link rel="stylesheet" href={fontCssUrl[variant]} />
             <link rel="preload" href={iconcdn()} as="style" onload="this.onload=null;this.rel='stylesheet'" />
             <noscript><link rel="stylesheet" href={iconcdn()} /></noscript>
             {hlTheme ? <link rel="preload" href={cdn('highlight.js', '9.12.0', 'styles/' + hlTheme + '.css')} as="style" onload="this.onload=null;this.rel='stylesheet'" /> : null}
             {hlTheme ? <noscript><link rel="stylesheet" href={cdn('highlight.js', '9.12.0', 'styles/' + hlTheme + '.css')} /></noscript> : null}
-            <link rel="preload" href={fontCssUrl[variant]} as="style" onload="this.onload=null;this.rel='stylesheet'" />
-            <noscript><link rel="stylesheet" href={fontCssUrl[variant]} /></noscript>
             <link rel="stylesheet" href={url_for('/css/' + variant + '.css')} />
             <Plugins site={site} config={config} helper={helper} page={page} head={true} />
 


### PR DESCRIPTION
## Summary

- 調查 PR #11 async CSS 導致文章頁手機 LCP 從 1.8s 退步至 5.8s 的根本原因
- 修正 Google Fonts 載入策略，保持 FontAwesome / highlight.js 非同步

## Root Cause

PR #11 將 Google Fonts CSS 從同步改為 `preload + onload` 非同步載入。

文章頁的 LCP 元素是**文章標題文字**（使用 Ubuntu 字體），非同步載入 Google Fonts 造成：
1. 瀏覽器先用 fallback 字體渲染標題 → LCP 候選被記錄
2. Google Fonts CSS 非同步載入 → `@font-face` 才被解析 → 字體檔案開始下載
3. Font swap 發生 → 瀏覽器重新評估 LCP → 時間更新至 swap 完成點
4. 手機網速慢，cascade 延遲嚴重 → LCP = 5.8s

## Fix

| CSS | 之前 | 修正後 | 原因 |
|-----|------|--------|------|
| Google Fonts | async (preload+onload) | **同步** + `preconnect` | LCP 元素依賴此字體 |
| FontAwesome | async | async | 不影響 LCP |
| highlight.js | async | async | 不影響 LCP |

加入 `<link rel="preconnect">` for `fonts.googleapis.com` + `fonts.gstatic.com` 降低同步載入的 DNS/TCP 延遲。

## Test Plan

- [ ] `npx hexo generate` 確認建置無誤
- [ ] 檢視文章頁 HTML，確認 Google Fonts 為同步 `<link rel="stylesheet">`
- [ ] Lighthouse 手機版文章頁 Performance Score ≥ 95
- [ ] Lighthouse 手機版 LCP ≤ 2.0s
- [ ] 確認 FontAwesome / highlight.js 仍為 preload 非同步載入

## Related

- Closes BOLA-25
- Caused by PR #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)