### PR TITLE
fix(perf): 改用 font-display:optional + async 載入 Google Fonts 修正手機 LCP

### DIFF
--- a/themes/icarus/layout/common/head.jsx
+++ b/themes/icarus/layout/common/head.jsx
@@ -72,8 +72,8 @@ module.exports = class extends Component {
 
         const language = page.lang || page.language || config.language;
         const fontCssUrl = {
-            default: fontcdn('Ubuntu:wght@400;600&family=Source+Code+Pro&display=swap', 'css2'),
-            cyberpunk: fontcdn('Oxanium:wght@300;400;600&family=Roboto+Mono&display=swap', 'css2')
+            default: fontcdn('Ubuntu:wght@400;600&family=Source+Code+Pro&display=optional', 'css2'),
+            cyberpunk: fontcdn('Oxanium:wght@300;400;600&family=Roboto+Mono&display=optional', 'css2')
         };
 
         let hlTheme, images;
@@ -197,7 +197,8 @@ module.exports = class extends Component {
             {favicon ? <link rel="icon" href={url_for(favicon)} /> : null}
             <link rel="preconnect" href="https://fonts.googleapis.com" />
             <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-            <link rel="stylesheet" href={fontCssUrl[variant]} />
+            <link rel="preload" href={fontCssUrl[variant]} as="style" onload="this.onload=null;this.rel='stylesheet'" />
+            <noscript><link rel="stylesheet" href={fontCssUrl[variant]} /></noscript>
             <link rel="preload" href={iconcdn()} as="style" onload="this.onload=null;this.rel='stylesheet'" />
             <noscript><link rel="stylesheet" href={iconcdn()} /></noscript>
             {hlTheme ? <link rel="preload" href={cdn('highlight.js', '9.12.0', 'styles/' + hlTheme + '.css')} as="style" onload="this.onload=null;this.rel='stylesheet'" /> : null}


### PR DESCRIPTION
## 問題

手機 LCP 高達 5.7–6.2s（目標 ≤2.0s），Performance Score 66–70。

根本原因：Google Fonts CSS 以**同步**方式載入（render-blocking），在 4G 模擬環境下延遲 3–5 秒。即使有 `preconnect`，跨域 DNS/TCP 握手仍不可避免。

## 修正

**`themes/icarus/layout/common/head.jsx`**

| 改動 | 前 | 後 |
|------|----|----|
| font-display | `display=swap` | `display=optional` |
| 載入方式 | 同步 `<link rel="stylesheet">` | async `<link rel="preload" as="style">` + `<noscript>` fallback |

### 為何 `font-display: optional`？

- Block period 僅 100ms，Swap period 為 0
- 瀏覽器不等字體，立即以 fallback 字體完成 LCP
- 無 swap → 無 CLS 退步
- 後續訪問命中快取後，字體正常顯示

### 為何 async 載入？

- Google Fonts CSS 不再阻塞首次渲染
- 配合 `optional` 使用，即使字體 CSS 晚到也不影響 LCP

## 驗收條件

- [ ] 手機 Performance ≥ 95
- [ ] 手機 LCP ≤ 2.0s
- [ ] CLS ≤ 0.01（不退步）

## 相關

- Closes BOLA-26
- 前次修正：PR #14（未達目標）

🤖 Generated with [Claude Code](https://claude.com/claude-code)