### PR TITLE
feat(migration): P3 routing + layouts — Astro 6 完整頁面系統

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
+import partytown from '@astrojs/partytown';
 
 export default defineConfig({
   site: 'https://bolaslien.github.io',
@@ -11,5 +12,10 @@ export default defineConfig({
   },
   integrations: [
     sitemap(),
+    partytown({
+      config: {
+        forward: ['dataLayer.push'],
+      },
+    }),
   ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.0.0",
+        "@fontsource/noto-sans-tc": "^5.2.9",
         "astro": "^6.0.0"
       },
       "devDependencies": {
@@ -610,6 +611,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/noto-sans-tc": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-tc/-/noto-sans-tc-5.2.9.tgz",
+      "integrity": "sha512-Z+pXTvXYrip79lPV9X1lCYO3UTys55P25VqcifDStIzdZ86I4R6t8dz+NhGd09YdbvHWvOCB5Icw1m7glKHPNQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@img/colour": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "bolas-blog",
       "version": "0.1.0",
       "dependencies": {
-        "@astrojs/partytown": "^2.1.7",
         "@astrojs/rss": "^4.0.18",
-        "@astrojs/sitemap": "^3.0.0",
         "@fontsource/noto-sans-tc": "^5.2.9",
         "astro": "^6.0.0"
       },
       "devDependencies": {
+        "@astrojs/partytown": "^2.1.7",
+        "@astrojs/sitemap": "^3.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
         "gray-matter": "^4.0.3",
@@ -72,6 +72,7 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@astrojs/partytown/-/partytown-2.1.7.tgz",
       "integrity": "sha512-dbffmNmJ+sAJ0/aXSaLX4aI04EZS/2C6Mm/+fmd4ikqWO7hV6nIi0sug8Z3c+yqedJNi1swFvpwluWmGjLHNzw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@qwik.dev/partytown": "^0.13.2",
@@ -105,6 +106,7 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
       "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sitemap": "^9.0.0",
@@ -1139,6 +1141,7 @@
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/@qwik.dev/partytown/-/partytown-0.13.2.tgz",
       "integrity": "sha512-Umls4bSkuzqLVcGvf8OgwIn/OldproSAbaQ/iYGe8VPYBpl2CaOSxabWwkeC72LDFqxVL0b0q8XlI8MuChDyzg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.7"
@@ -1674,6 +1677,7 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1683,6 +1687,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
       "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1854,6 +1859,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -2415,6 +2421,7 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -4642,6 +4649,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
       "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^24.9.2",
@@ -4661,6 +4669,7 @@
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -4670,6 +4679,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/smol-toml": {
@@ -4728,6 +4738,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stringify-entities": {
@@ -4984,6 +4995,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bolas-blog",
       "version": "0.1.0",
       "dependencies": {
+        "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.0.0",
         "@fontsource/noto-sans-tc": "^5.2.9",
         "astro": "^6.0.0"
@@ -76,6 +77,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -1092,6 +1104,18 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@nodable/entities": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
+      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/@oslojs/encoding": {
@@ -2518,6 +2542,42 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^1.1.0"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
+      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^1.1.0",
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fdir": {
@@ -4025,6 +4085,21 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -4653,6 +4728,18 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/svgo": {
       "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bolas-blog",
       "version": "0.1.0",
       "dependencies": {
+        "@astrojs/partytown": "^2.1.7",
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.0.0",
         "@fontsource/noto-sans-tc": "^5.2.9",
@@ -65,6 +66,16 @@
         "unist-util-visit": "^5.1.0",
         "unist-util-visit-parents": "^6.0.2",
         "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@astrojs/partytown": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/partytown/-/partytown-2.1.7.tgz",
+      "integrity": "sha512-dbffmNmJ+sAJ0/aXSaLX4aI04EZS/2C6Mm/+fmd4ikqWO7hV6nIi0sug8Z3c+yqedJNi1swFvpwluWmGjLHNzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@qwik.dev/partytown": "^0.13.2",
+        "mrmime": "^2.0.1"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -1123,6 +1134,21 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
+    },
+    "node_modules/@qwik.dev/partytown": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@qwik.dev/partytown/-/partytown-0.13.2.tgz",
+      "integrity": "sha512-Umls4bSkuzqLVcGvf8OgwIn/OldproSAbaQ/iYGe8VPYBpl2CaOSxabWwkeC72LDFqxVL0b0q8XlI8MuChDyzg==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.4.7"
+      },
+      "bin": {
+        "partytown": "bin/partytown.cjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
@@ -2383,6 +2409,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dset": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "migrate:posts": "tsx scripts/migrate-posts.mts"
   },
   "dependencies": {
+    "@astrojs/partytown": "^2.1.7",
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.0.0",
     "@fontsource/noto-sans-tc": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "migrate:posts": "tsx scripts/migrate-posts.mts"
   },
   "dependencies": {
+    "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.0.0",
     "@fontsource/noto-sans-tc": "^5.2.9",
     "astro": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.0.0",
+    "@fontsource/noto-sans-tc": "^5.2.9",
     "astro": "^6.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "migrate:posts": "tsx scripts/migrate-posts.mts"
   },
   "dependencies": {
-    "@astrojs/partytown": "^2.1.7",
     "@astrojs/rss": "^4.0.18",
-    "@astrojs/sitemap": "^3.0.0",
     "@fontsource/noto-sans-tc": "^5.2.9",
     "astro": "^6.0.0"
   },
   "devDependencies": {
+    "@astrojs/partytown": "^2.1.7",
+    "@astrojs/sitemap": "^3.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "gray-matter": "^4.0.3",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,33 @@
+---
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const { title, description } = Astro.props;
+
+const SITE_NAME = 'Bolas 的開發與學習筆記';
+const finalTitle = title.includes(SITE_NAME) ? title : `${title} · ${SITE_NAME}`;
+---
+
+<!DOCTYPE html>
+<html lang="zh-TW">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>{finalTitle}</title>
+    {description && <meta name="description" content={description} />}
+    <meta property="og:title" content={finalTitle} />
+    {description && <meta property="og:description" content={description} />}
+    <meta property="og:type" content="website" />
+  </head>
+  <body>
+    <nav>
+      <a href="/blog/">首頁</a>
+      <a href="/blog/about/">About</a>
+    </nav>
+    <main>
+      <slot />
+    </main>
+  </body>
+</html>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,6 @@
 ---
+import '@fontsource/noto-sans-tc';
+
 interface Props {
   title: string;
   description?: string;
@@ -31,3 +33,10 @@ const finalTitle = title.includes(SITE_NAME) ? title : `${title} · ${SITE_NAME}
     </main>
   </body>
 </html>
+
+<style is:global>
+  html,
+  body {
+    font-family: 'Noto Sans TC', sans-serif;
+  }
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,6 +22,14 @@ const finalTitle = title.includes(SITE_NAME) ? title : `${title} · ${SITE_NAME}
     <meta property="og:title" content={finalTitle} />
     {description && <meta property="og:description" content={description} />}
     <meta property="og:type" content="website" />
+    <!-- GA4 with Partytown -->
+    <script type="text/partytown" async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+    <script type="text/partytown" is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-XXXXXXXXXX');
+    </script>
   </head>
   <body>
     <nav>

--- a/src/pages/[year]/[month]/[day]/[slug].astro
+++ b/src/pages/[year]/[month]/[day]/[slug].astro
@@ -6,10 +6,9 @@ import { formatDateParams } from '../../../../utils/dates';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
-return posts.map((post) => {
+  return posts.map((post) => {
     const { year, month, day } = formatDateParams(post.data.date);
-    // slug 從 post.id 萃取（移除 /index.md 後綴若有）
-    const slug = post.id.replace(/\/index\.md$/, '');
+    const slug = post.id;
     return {
       params: { year, month, day, slug },
       props: { post },

--- a/src/pages/[year]/[month]/[day]/[slug].astro
+++ b/src/pages/[year]/[month]/[day]/[slug].astro
@@ -2,7 +2,7 @@
 import type { CollectionEntry } from 'astro:content';
 import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../../../layouts/BaseLayout.astro';
-import { formatDateParams } from '../../../../utils/dates';
+import { formatDateParams, formatTaipeiIso } from '../../../../utils/dates';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
@@ -25,7 +25,7 @@ const { year, month, day } = formatDateParams(post.data.date);
   <article>
     <header>
       <h1>{post.data.title}</h1>
-      <time datetime={post.data.date.toISOString()}>
+      <time datetime={formatTaipeiIso(post.data.date)}>
         {year}-{month}-{day}
       </time>
       {post.data.tags.length > 0 && (

--- a/src/pages/[year]/[month]/[day]/[slug].astro
+++ b/src/pages/[year]/[month]/[day]/[slug].astro
@@ -1,5 +1,5 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import type { InferGetStaticPropsType } from 'astro';
 import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import { formatDateParams, formatTaipeiIso } from '../../../../utils/dates';
@@ -16,7 +16,8 @@ export async function getStaticPaths() {
   });
 }
 
-const { post } = Astro.props as { post: CollectionEntry<'posts'> };
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+const { post } = Astro.props as Props;
 const { Content } = await render(post);
 const { year, month, day } = formatDateParams(post.data.date);
 ---

--- a/src/pages/[year]/[month]/[day]/[slug].astro
+++ b/src/pages/[year]/[month]/[day]/[slug].astro
@@ -1,0 +1,38 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { getCollection, render } from 'astro:content';
+import BaseLayout from '../../../../layouts/BaseLayout.astro';
+import { formatDateParams } from '../../../../utils/dates';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('posts');
+return posts.map((post) => {
+    const { year, month, day } = formatDateParams(post.data.date);
+    // slug 從 post.id 萃取（移除 /index.md 後綴若有）
+    const slug = post.id.replace(/\/index\.md$/, '');
+    return {
+      params: { year, month, day, slug },
+      props: { post },
+    };
+  });
+}
+
+const { post } = Astro.props as { post: CollectionEntry<'posts'> };
+const { Content } = await render(post);
+const { year, month, day } = formatDateParams(post.data.date);
+---
+
+<BaseLayout title={post.data.title} description={post.data.description}>
+  <article>
+    <header>
+      <h1>{post.data.title}</h1>
+      <time datetime={post.data.date.toISOString()}>
+        {year}-{month}-{day}
+      </time>
+      {post.data.tags.length > 0 && (
+        <p class="tags">{post.data.tags.join(', ')}</p>
+      )}
+    </header>
+    <Content />
+  </article>
+</BaseLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,36 +1,26 @@
 ---
-// P2 手動 inline from source/about/index.md
-// P3 會統一 layout
+import BaseLayout from '../layouts/BaseLayout.astro';
 ---
-<!DOCTYPE html>
-<html lang="zh-TW">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>About · Bolas 的開發與學習筆記</title>
-  </head>
-  <body>
-    <main>
-      <h1>About</h1>
 
-      <h2>關於我</h2>
-      <p>
-        嗨，我是連小艾，一名前端工程師。<br />
-        熟悉的技能為 Scss/Less, Vue, Webpack, Gulp, Git, Linux command line（使用過 docker, cypress）。
-      </p>
-      <p>
-        我喜歡團隊協作的環境，視團隊為優先，當我協助提升團隊工作效率、或是引導團隊解決難題的時候，我會感到很有成就感。<br />
-        若想要了解更多我的經歷，可以參考<a href="https://www.linkedin.com/in/bolaslien/">我的 Linkedin</a>。
-      </p>
+<BaseLayout title="About">
+  <h1>About</h1>
 
-      <h2>關於部落格</h2>
-      <p>這裡記錄了我的技術學習筆記、踩過的坑，以及軟體開發心得筆記。</p>
+  <h2>關於我</h2>
+  <p>
+    嗨，我是連小艾，一名前端工程師。<br />
+    熟悉的技能為 Scss/Less, Vue, Webpack, Gulp, Git, Linux command line（使用過 docker, cypress）。
+  </p>
+  <p>
+    我喜歡團隊協作的環境，視團隊為優先，當我協助提升團隊工作效率、或是引導團隊解決難題的時候，我會感到很有成就感。<br />
+    若想要了解更多我的經歷，可以參考<a href="https://www.linkedin.com/in/bolaslien/">我的 Linkedin</a>。
+  </p>
 
-      <h2>聯絡方式</h2>
-      <ul>
-        <li><a href="https://www.linkedin.com/in/bolaslien/">Linkedin</a></li>
-        <li><a href="mailto:bolaslien@gmail.com">Email</a></li>
-      </ul>
-    </main>
-  </body>
-</html>
+  <h2>關於部落格</h2>
+  <p>這裡記錄了我的技術學習筆記、踩過的坑，以及軟體開發心得筆記。</p>
+
+  <h2>聯絡方式</h2>
+  <ul>
+    <li><a href="https://www.linkedin.com/in/bolaslien/">Linkedin</a></li>
+    <li><a href="mailto:bolaslien@gmail.com">Email</a></li>
+  </ul>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,18 +1,26 @@
 ---
-// P1 placeholder — 真正首頁在 P3 實作
+import { getCollection } from 'astro:content';
+import { formatDateParams } from '../utils/dates';
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const posts = await getCollection('posts');
+const sorted = posts.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 ---
-<!DOCTYPE html>
-<html lang="zh-TW">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>Bolas 的開發與學習筆記（Astro 遷移中）</title>
-  </head>
-  <body>
-    <main>
-      <h1>Astro 遷移中</h1>
-      <p>P1 scaffold 完成。真正的首頁會在 P3 實作。</p>
-      <p>Base path: <code>/blog</code>, trailing slash: always.</p>
-    </main>
-  </body>
-</html>
+
+<BaseLayout title="Bolas 的開發與學習筆記">
+  <h1>文章列表</h1>
+  <ul>
+    {sorted.map((post) => {
+      const { year, month, day } = formatDateParams(post.data.date);
+      const href = `/blog/${year}/${month}/${day}/${post.id}/`;
+      return (
+        <li>
+          <a href={href}>{post.data.title}</a>
+          <time datetime={post.data.date.toISOString()}>{year}-{month}-{day}</time>
+          <p>{post.data.description}</p>
+          {post.data.tags.length > 0 && <p class="tags">{post.data.tags.join(', ')}</p>}
+        </li>
+      );
+    })}
+  </ul>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
-import { formatDateParams } from '../utils/dates';
+import { formatDateParams, formatTaipeiIso } from '../utils/dates';
 import BaseLayout from '../layouts/BaseLayout.astro';
 
 const posts = await getCollection('posts');
@@ -16,7 +16,7 @@ const sorted = posts.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf(
       return (
         <li>
           <a href={href}>{post.data.title}</a>
-          <time datetime={post.data.date.toISOString()}>{year}-{month}-{day}</time>
+          <time datetime={formatTaipeiIso(post.data.date)}>{year}-{month}-{day}</time>
           <p>{post.data.description}</p>
           {post.data.tags.length > 0 && <p class="tags">{post.data.tags.join(', ')}</p>}
         </li>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,25 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+import { formatDateParams } from '../utils/dates';
+
+export async function GET(context: APIContext) {
+  const posts = await getCollection('posts');
+  const sorted = posts.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+
+  return rss({
+    title: "Bolas 的開發與學習筆記",
+    description: "前端工程師的技術學習筆記、踩過的坑，以及軟體開發心得",
+    site: context.site!,
+    items: sorted.map((post) => {
+      const { year, month, day } = formatDateParams(post.data.date);
+      return {
+        title: post.data.title,
+        pubDate: post.data.date,
+        description: post.data.description,
+        link: `/blog/${year}/${month}/${day}/${post.id}/`,
+      };
+    }),
+    customData: `<language>zh-tw</language>`,
+  });
+}


### PR DESCRIPTION
## Summary

- **BaseLayout.astro**：統一 head（charset/viewport/title/og tags）+ nav（首頁/About），所有頁面共用
- **動態路由** `[year]/[month]/[day]/[slug].astro`：getStaticPaths 從 Content Collection 取 60 篇，URL 格式 /blog/YYYY/MM/DD/slug/
- **首頁** `index.astro`：60 篇文章倒序列表（title/date/description/tags），取代 P1 placeholder
- **Noto Sans TC** 字型：@fontsource/noto-sans-tc，套用至 BaseLayout
- **RSS feed** `rss.xml.ts`：@astrojs/rss，60 篇完整 feed，/blog/rss.xml
- **GA4 + Partytown**：@astrojs/partytown + GA4 placeholder（G-XXXXXXXXXX 待替換）
- **`astro build` exit 0**：62 頁面（60 篇文章 + index + about）+ rss.xml

## Technical Notes

- Astro 6 `render(entry)` API（非舊版 `entry.render()`）
- `<time datetime>` 統一使用 `formatTaipeiIso`（台北時區 ISO，與顯示日期一致）
- post.id 為純 slug（Astro 6 glob loader 自動去除 `/index.md`）
- build-time integrations（sitemap/partytown）移至 devDependencies

## Test Plan

- [ ] `npm test` — 74 tests passed
- [ ] `npm run build` — exit 0，62 pages + rss.xml
- [ ] 首頁 /blog/ 顯示 60 篇文章（倒序）
- [ ] 任意文章頁 /blog/YYYY/MM/DD/slug/ 可 render
- [ ] /blog/about/ 使用 BaseLayout（nav 可見）
- [ ] /blog/rss.xml 含 60 篇 item

🤖 Generated with [Claude Code](https://claude.com/claude-code)