### PR TITLE
feat(post-content): 加文章表格樣式（C 預設 + D opt-in zebra）

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import sitemap from '@astrojs/sitemap';
 import partytown from '@astrojs/partytown';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import rehypeTableWrap from './plugins/rehype-table-wrap.mjs';
 
 /** @param {Date} date */
 function formatDateParams(date) {
@@ -59,6 +60,9 @@ export default defineConfig({
   trailingSlash: 'always',
   build: {
     format: 'directory',
+  },
+  markdown: {
+    rehypePlugins: [rehypeTableWrap],
   },
   fonts: [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "node-html-parser": "^7.1.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0",
+        "unist-util-visit": "^5.1.0",
         "vitest": "^3.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "node-html-parser": "^7.1.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
+    "unist-util-visit": "^5.1.0",
     "vitest": "^3.0.0"
   }
 }

--- a/plugins/rehype-table-wrap.mjs
+++ b/plugins/rehype-table-wrap.mjs
@@ -1,0 +1,37 @@
+// plugins/rehype-table-wrap.mjs
+// --------------------------------------------------------------------
+// Wrap every <table> in markdown-rendered HTML with
+// <div class="table-wrap">…</div>, so the post stylesheet can attach
+// horizontal-scroll behaviour + framing on a single hook.
+//
+// Idempotent: if a table is already inside a .table-wrap, leave it.
+// --------------------------------------------------------------------
+
+import { visit } from 'unist-util-visit';
+
+const WRAP_CLASS = 'table-wrap';
+
+function hasClass(node, name) {
+  const cls = node?.properties?.className;
+  if (!cls) return false;
+  if (Array.isArray(cls)) return cls.includes(name);
+  return String(cls).split(/\s+/).includes(name);
+}
+
+export default function rehypeTableWrap() {
+  return (tree) => {
+    visit(tree, 'element', (node, index, parent) => {
+      if (node.tagName !== 'table') return;
+      if (!parent || typeof index !== 'number') return;
+
+      if (parent.tagName === 'div' && hasClass(parent, WRAP_CLASS)) return;
+
+      parent.children[index] = {
+        type: 'element',
+        tagName: 'div',
+        properties: { className: [WRAP_CLASS] },
+        children: [node],
+      };
+    });
+  };
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -296,6 +296,94 @@ a:hover { color: var(--denim-deep); }
   text-decoration-color: var(--denim);
 }
 
+/* ============================ Tables =============================
+   Convention:
+     • Plain markdown tables → Direction C (default)
+     • Wrap a table in `<div class="table-zebra">…</div>` → Direction D
+   `.table-wrap` is injected by `plugins/rehype-table-wrap.mjs` so the
+   writer never needs to add it manually.
+   ================================================================= */
+
+.prose table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 14.5px;
+  line-height: 1.7;
+  color: var(--fg-2);
+  font-family: var(--font-sans);
+  font-variant-numeric: tabular-nums;
+  margin: 0;
+}
+.prose th,
+.prose td {
+  text-align: left;
+  vertical-align: top;
+  font-weight: inherit;
+}
+.prose th[align="right"],
+.prose td[align="right"] { text-align: right; }
+.prose th[align="center"],
+.prose td[align="center"] { text-align: center; }
+
+.prose .table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  margin: var(--space-4) 0;
+}
+.prose .table-wrap table { min-width: 460px; }
+
+/* C · Default — denim-soft header band, framed */
+.prose table thead th {
+  background: var(--denim-soft);
+  color: var(--denim-deep);
+  font-weight: 600;
+  font-size: 12.5px;
+  letter-spacing: 0.02em;
+  padding: 10px 16px;
+}
+.prose table tbody td {
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  transition: background-color 120ms linear, color 120ms linear;
+}
+.prose table tbody tr:first-child td { border-top: 0; }
+.prose table tbody tr:hover td {
+  background: var(--bg-2);
+  color: var(--fg-1);
+}
+
+/* D · Opt-in — warm zebra, hairline top/bottom */
+.prose .table-zebra .table-wrap {
+  border-left: 0;
+  border-right: 0;
+  border-radius: 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+.prose .table-zebra table thead th {
+  background: transparent;
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 500;
+  padding: 11px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.prose .table-zebra table tbody td {
+  padding: 11px 16px;
+  border-top: 0;
+  transition: background-color 120ms linear;
+}
+.prose .table-zebra table tbody tr:nth-child(odd) td { background: var(--bg-2); }
+.prose .table-zebra table tbody tr:hover td {
+  background: var(--denim-soft);
+  color: var(--fg-2);
+}
+
 /* ========================== Layout shell ========================== */
 .page-wrapper {
   max-width: var(--content-max);


### PR DESCRIPTION
- 新增 plugins/rehype-table-wrap.mjs：build 時自動把 <table> 包進 .table-wrap， 寫作端用純 markdown 即可，wrapper 完全不用碰
- astro.config.mjs：markdown.rehypePlugins 掛上 table wrap plugin
- src/styles/global.css：加 .prose table / .prose .table-wrap / .prose .table-zebra 兩種樣式（C 預設 = denim-soft header band；D 包 <div class="table-zebra"> = warm zebra）
- 依賴：unist-util-visit

設計來源：Claude Design bundle（bolas-blog-design-system, chat4 表格設計方案） selector 從原設計的 .post-content 改為現有 codebase 的 .prose