### PR TITLE
chore(seo): redirect 舊 putty 中文 URL 到 ssh-passwordless-login-with-putty

### DIFF
--- a/public/2020/09/21/putty使用ssh登入遠端無須密碼/index.html
+++ b/public/2020/09/21/putty使用ssh登入遠端無須密碼/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+<meta charset="utf-8">
+<title>已搬遷：putty 使用 ssh 登入遠端無須密碼</title>
+<link rel="canonical" href="https://bolaslien.github.io/blog/2020/09/21/ssh-passwordless-login-with-putty/">
+<meta http-equiv="refresh" content="0;url=/blog/2020/09/21/ssh-passwordless-login-with-putty/">
+</head>
+<body>
+<p>本頁已搬遷，將自動跳轉。若未跳轉請<a href="/blog/2020/09/21/ssh-passwordless-login-with-putty/">點此前往新位置</a>。</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- 為被刪除的舊文章 `/2020/09/21/putty使用ssh登入遠端無須密碼/` 加上 redirect HTML，導向新 slug `ssh-passwordless-login-with-putty/`，保留 GSC 既有流量與 SEO 連結權重
- 採手寫 meta refresh + canonical 放 `public/`，繞過 Astro 6 `redirects` 設定在 `base: '/blog'` 下產出缺 prefix + 強制 noindex 的 bug
- GitHub Pages 純靜態無真 301，meta refresh 0 秒是 Google 認可的替代方案

## 限制
- 非真 301，link equity 傳遞效果略弱於 server-side redirect、生效時間略長
- 要真 301 需換 host（Cloudflare Pages / Netlify 支援 `_redirects`）

## Test plan
- [x] `npm run build` 通過，產出 `dist/2020/09/21/putty使用ssh登入遠端無須密碼/index.html`
- [x] HTML 內容驗證：canonical 含 `/blog`、meta refresh 含 `/blog`、無 `noindex`
- [x] `npm run preview` curl 舊 URL 回 200 + 正確 redirect HTML
- [x] curl 新目標 URL 回 200
- [ ] Merge 後實地用瀏覽器訪問舊 URL 確認 meta refresh 跳轉
- [ ] GSC URL Inspection 確認 Google 視為 redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)