### PR TITLE
docs(rules): 加 post-tables.md（C 視覺停頓 / D 數據橫掃）

### DIFF
--- a/.claude/rules/post-tables.md
+++ b/.claude/rules/post-tables.md
@@ -1,0 +1,67 @@
+---
+description: 文章內 markdown table 兩種樣式（C 預設 / D zebra）的適用情境
+---
+
+# Post Table 樣式規則
+
+文章 markdown 表格有兩種樣式，由 `src/styles/global.css` 的 `.prose table` 區塊定義。
+`.table-wrap`（橫向 scroll + 邊框）由 `plugins/rehype-table-wrap.mjs` 在 build 時自動加上，寫作端不用手動包。
+
+兩種樣式不是用「資料量多寡」分，是用**語意**分：
+
+- C = 視覺停頓、讓讀者「停下來看」
+- D = 數據橫掃、讓眼睛「沿著一列比對」
+
+## C · Denim-soft header band（預設）
+
+純 markdown table，不用加任何 wrapper。
+
+```markdown
+| 指標 | 說明 | 分數 |
+| --- | --- | --- |
+| 程式碼可讀性 | 命名、結構、註解一致性 | 82 |
+| 測試覆蓋 | 單元、整合、E2E 加權 | 74 |
+```
+
+特徵：
+
+- 表頭吃進一塊 denim-soft 色塊
+- 整張表用 `radius-md` 圓角框起來
+- hover 整列換 `--bg-2` 高亮
+- 視覺重量比 zebra 重，比較「成形」
+
+**適合：** 文章中段需要明顯「這裡有資訊」的整理區塊。例如定義性對照、概念說明、評分整理。讓讀者在閱讀流中視覺停頓、知道這是一塊獨立的資訊。
+
+## D · Warm zebra（opt-in）
+
+外面包 `<div class="table-zebra">`，HTML 寫在 markdown 內。
+
+```markdown
+<div class="table-zebra">
+
+| 專案 | stars | issues | 最後更新 |
+| --- | --- | --- | --- |
+| astro-paper | 3.4k | 12 | 2 天前 |
+| hexo-theme-icarus | 2.1k | 38 | 3 週前 |
+
+</div>
+```
+
+注意：`<div>` 上下要留空行，否則 markdown parser 不會解析裡面的 table。
+
+特徵：
+
+- 表頭 mono 字體 + uppercase（像 console / data table）
+- 沒有左右框，只有上下 hairline
+- **沒有列分隔線，靠 bg-1 / bg-2 底色交錯斷行**
+- hover 用 denim-soft 高亮
+
+**適合：** 數據型對照，讓眼睛沿著一列橫掃。例如多版本規格比較、benchmark 數值、多套件選項對照。
+
+**注意：** bg-2 在 reading-first 的版面裡聲量最大，使用要節制 — 不要一篇文章塞兩三張 zebra，會搶走內文焦點。
+
+## 決策原則
+
+- 預設用 C，除非要做數據型橫掃對照
+- 不要為了「換口味」用 D，要對應到「眼睛要怎麼讀這張表」的語意
+- 同一篇文章不要連續出現多張 D（聲量問題）


### PR DESCRIPTION
## Summary

對應 #23 加的兩種表格樣式（C 預設 / D zebra），把適用情境寫成 `.claude/rules/post-tables.md`。

決策原則照 design 提案的原意：

- **C · Denim-soft header band（預設）** — 視覺停頓、讓讀者「停下來看」。文章中段需要明顯「這裡有資訊」的整理區塊。
- **D · Warm zebra（opt-in）** — 數據橫掃、讓眼睛「沿著一列比對」。多版本規格、benchmark、選項對照。
- 標註 D 的注意事項：bg-2 聲量大，使用要節制，一篇文章不要連續多張。

## 機制

`.claude/rules/*.md` 會被 Claude Code 在每個 session 開始時自動載入為 project instructions（跟 `post-frontmatter.md`、`font-optimization.md` 同機制），所以下個 session 寫文章碰到表格時會記得依這條規則判斷 C / D。

## Test plan

- [ ] 合併後開新 session，確認 `post-tables.md` 內容會出現在 session 起始 context 的「project instructions」區塊
- [ ] 之後寫文章需要表格時，觀察是否會依語意主動建議 C / D（不好用再回來調）

🤖 Generated with [Claude Code](https://claude.com/claude-code)