### PR TITLE
seo: add canonical tag to every page

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -27,6 +27,7 @@ const OG_IMAGE = new URL('/blog/img/og_image.png', Astro.site).href;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/blog/favicon.svg" />
+    <link rel="canonical" href={Astro.url.href} />
     <title>{finalTitle}</title>
     {description && <meta name="description" content={description} />}
     <meta property="og:title" content={finalTitle} />


### PR DESCRIPTION
## 問題
每個頁面缺少 `<link rel="canonical">`，Google 在處理 trailing slash 或任何 URL 變體時無法確定正規版本，可能造成重複內容問題。

## 變更
在 `BaseLayout.astro` 的 `<head>` 加上一行：

```html
<link rel="canonical" href={Astro.url.href} />
```

`Astro.url.href` 會自動帶入當前頁面的完整 URL（含 trailing slash），與 `og:url` 行為一致，不需額外傳 prop。

## 影響範圍
全站所有頁面（首頁、文章頁、標籤、歸檔、About），單一改動點。