### PR TITLE
seo: add JSON-LD BlogPosting schema and Twitter Card tags

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -35,6 +35,11 @@ const OG_IMAGE = new URL('/blog/img/og_image.png', Astro.site).href;
     <meta property="og:type" content={ogType} />
     <meta property="og:url" content={Astro.url.href} />
     <meta property="og:image" content={OG_IMAGE} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={finalTitle} />
+    {description && <meta name="twitter:description" content={description} />}
+    <meta name="twitter:image" content={OG_IMAGE} />
+    <slot name="head" />
     <!-- GA4 with Partytown -->
     <script type="text/partytown" async src="https://www.googletagmanager.com/gtag/js?id=G-SG50KRG586"></script>
     <script type="text/partytown" is:inline>

--- a/src/pages/[year]/[month]/[day]/[slug].astro
+++ b/src/pages/[year]/[month]/[day]/[slug].astro
@@ -39,6 +39,21 @@ const { post, prev, next } = Astro.props as Props;
 const { Content } = await render(post);
 const { year, month, day } = formatDateParams(post.data.date);
 const dateStr = `${year}-${month}-${day}`;
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BlogPosting',
+  headline: post.data.title,
+  description: post.data.description,
+  datePublished: formatTaipeiIso(post.data.date),
+  url: Astro.url.href,
+  author: {
+    '@type': 'Person',
+    name: 'Bolas Lien',
+    url: new URL('/blog/about/', Astro.site).href,
+  },
+  image: new URL('/blog/img/og_image.png', Astro.site).href,
+};
 ---
 
 <BaseLayout
@@ -47,6 +62,7 @@ const dateStr = `${year}-${month}-${day}`;
   ogType="article"
   activeNav="Posts"
 >
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   <article class="post-article">
     <a href="/blog/" class="back-link">
       <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">


### PR DESCRIPTION
## 變更

### Twitter Card（`BaseLayout.astro`）
加 `twitter:card`、`twitter:title`、`twitter:description`、`twitter:image`，讓文章在 X/Twitter 分享時顯示大圖預覽。同時加了 `<slot name="head" />` 讓各頁面可以注入額外的 head 內容。

### JSON-LD BlogPosting schema（`[slug].astro`）
每篇文章頁的 `<head>` 加入 `application/ld+json`，包含：
- `headline`、`description`
- `datePublished`（Taipei ISO 格式）
- `url`（當前頁完整 URL）
- `author`（Bolas Lien，連到 /about/）
- `image`（OG image）

透過 `<slot name="head">` 注入，不改動 BaseLayout 的主流程。Google 抓到結構化資料後，文章在搜尋結果中有機會出現日期、作者等 rich result。